### PR TITLE
fix #19 login problem with request token

### DIFF
--- a/app/src/main/java/org/pquery/webdriver/RetrievePageTask.java
+++ b/app/src/main/java/org/pquery/webdriver/RetrievePageTask.java
@@ -155,7 +155,7 @@ public class RetrievePageTask extends RetriableTask<Source> {
             }
 
             List<Pair<String,String>> nameValuePairs = loginFormExtra.toNameValuePairs();
-
+            nameValuePairs = nameValuePairs.subList(1, nameValuePairs.size());
 
             progressReport(0, res.getString(R.string.login_geocaching_com), res.getString(R.string.requesting));
 


### PR DESCRIPTION
There are two form fields on the login page (one for logout) and the field `__RequestVerificationToken` is inserted twice.
I just strip the first form field from the list of nameValuePairs. It works this way, but feels very hacky.

@robneild if you have a better idea to only read the form fields from the second form, you are welcome.